### PR TITLE
GOV-335, add onLoginFailure hook to redirect rogue users from other vpcs

### DIFF
--- a/shared/router.coffee
+++ b/shared/router.coffee
@@ -152,3 +152,10 @@ if Meteor.isClient
         console.log("set fromWhere", Iron.Location.get().path, Router.current()?.route?.getName?(), exclusions)
         Session.set('fromWhere', Iron.Location.get().path)
 ###
+
+
+if Meteor.isClient
+  #catch onlogin failures and redirect to static error page
+  Accounts.onLoginFailure (err) ->
+    console.log("on login error:" + JSON.stringify(err))
+    Router.go 'othervpc'

--- a/shared/router.coffee
+++ b/shared/router.coffee
@@ -158,4 +158,6 @@ if Meteor.isClient
   #catch onlogin failures and redirect to static error page
   Accounts.onLoginFailure (err) ->
     console.log("on login error:" + JSON.stringify(err))
-    Router.go 'othervpc'
+    errno = err?.error?.error
+    if errno == 418 or errno == Accounts.LoginCancelledError.numericError
+      Router.go 'othervpc'


### PR DESCRIPTION
Redirect failed logins to static error page. 

@lnader I have added the error route in unity. This is ready for review