### PR TITLE
GOV-461, show confirm-email screen on forgot password even if the reset fails

### DIFF
--- a/client/views/forgotPassword/forgotPassword.coffee
+++ b/client/views/forgotPassword/forgotPassword.coffee
@@ -36,9 +36,10 @@ Template.entryForgotPassword.events
       Meteor.call('entryForgotPassword',Session.get('email'), (err, data) ->
         if err
           Session.set('entryError', "Failed to reset password")
-        else
-          Session.set('_accountsEntryProcessing', false)
-          Router.go('/confirm-email');
+          console.log "Forgot password failed for #{Session.get('email')} with error #{JSON.toString(err)}"
+        Router.go('/confirm-email');
+        Session.set('_accountsEntryProcessing', false)
+
 
       )
 


### PR DESCRIPTION
This is to prevent attackers from fishing valid emails from Riffyn. 
Do not show errors on failed reset password/ forgot password calls. Log the errors and proceed.